### PR TITLE
Basic_authenitication_2_up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,12 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
+  protect_from_forgery with: :exception
 
   private
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == 'admin' && password == '2222'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 end


### PR DESCRIPTION
#What
メルカリ開発においてbasic認証のパスワードとユーザー名を環境変数に定義する

#Why
本アプリケーションにおいて本機能はコードを読める第三者に不正にBasic認証を突破されてしまうのを防ぐため